### PR TITLE
HOTFIX: Add Missing Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ mdurl==0.1.2
 packaging==24.1
 passlib==1.7.4
 pluggy==1.5.0
+psycopg2-binary==2.9.9
 pydantic==2.9.2
 pydantic-settings==2.5.2
 pydantic_core==2.23.4


### PR DESCRIPTION
This PR makes a hotfix related to missing Python packages.